### PR TITLE
Add format:check and document evaluator props

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,5 @@ export default () => <TscircuitIframe fsMap={fsMap} />
 | `onError` | `(error: Error) => void` | Called when an error occurs while running or rendering code. |
 | `onEditEvent` | `(editEvent: any) => void` | Called when the user performs an edit action. |
 | `projectUrl` | `string` | Optional project URL used when reporting autorouting issues. |
+| `evalVersion` | `string` | Version of the tscircuit evaluator to use. Defaults to the latest release. |
+| `forceLatestEvalVersion` | `boolean` | If `true`, always use the latest evaluator, overriding `evalVersion`. Defaults to `true` when `evalVersion` is not provided. |

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "cosmos",
     "format": "biome format --write .",
+    "format:check": "biome format .",
     "vercel-build": "bun run build:site",
     "build:site": "cosmos-export",
     "build": "tsup-node lib/TscircuitIframe.tsx --format esm --dts --clean"


### PR DESCRIPTION
## Summary
- document `evalVersion` and `forceLatestEvalVersion` props in README
- add `format:check` script for Biome without write flag

## Testing
- `bun run format:check`
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68843d08b380832e9725a632377e34e6